### PR TITLE
Correctly handle comments as children of at-groups. Fix #2

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -140,6 +140,8 @@ function stringifyRule(node) {
  * Reduce an array by applying a function to each item and retaining the truthy
  * results.
  *
+ * When `item.type` is `'comment'` `stringifyComment` will be applied instead.
+ *
  * @param {Array} items array to reduce
  * @param {Function} fn function to call for each item in the array
  *   @returns {Mixed} Truthy values will be retained, falsy values omitted
@@ -147,12 +149,11 @@ function stringifyRule(node) {
  */
 function reduce(items, fn) {
   return items.reduce(function (results, item) {
-    var result = fn(item);
+    var result = (item.type === 'comment') ? stringifyComment(item) : fn(item);
     result && results.push(result);
     return results;
   }, []);
 }
-
 
 /**
  * Stringify an AST node with the assumption that it represents a block of
@@ -203,9 +204,8 @@ function stringifyChildren(children, fn) {
  * @returns {String}
  */
 function stringifyDeclaration(node) {
-  switch (node.type) {
-  case 'property': return stringifyProperty(node);
-  case 'comment': return stringifyComment(node);
+  if (node.type === 'property') {
+    return stringifyProperty(node);
   }
 
   DEBUG && debug('stringifyDeclaration: unexpected node:', JSON.stringify(node));

--- a/test/comments.js
+++ b/test/comments.js
@@ -111,6 +111,47 @@ describe('Comments', function () {
         }
       });
     });
+
+    it('inside an at-group', function () {
+      var css = [
+        '@media (max-width: 1024) {',
+        '/* boom! */',
+        '',
+        '.foo {',
+        'color: blue;',
+        '}',
+        '}'
+      ].join('\n');
+
+      var ast = mensch.parse(css, options);
+
+      assert.deepEqual(ast, {
+        type: 'stylesheet',
+        stylesheet: {
+          rules: [{
+            type: 'media',
+            name: '(max-width: 1024)',
+            prefix: undefined,
+            rules: [{
+              type: 'comment',
+              text: ' boom! '
+            }, {
+              type: 'rule',
+              selectors: ['.foo'],
+              declarations: [{
+                type: 'property',
+                name: 'color',
+                value: 'blue'
+              }]
+            }]
+          }]
+        }
+      });
+
+      var out = mensch.stringify(ast, options);
+
+      assert.equal(out, css);
+    });
   });
 
   describe('are not supported when', function () {


### PR DESCRIPTION
Moved the comment logic into `reduce`, as it is the common code path for all at-group children whether rules, declarations, or comments.
