### PR TITLE
Implement @document, @namespace and @page; closes #4

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -39,7 +39,8 @@ function lex(css) {
     'viewport',
     { name: 'namespace', state: 'before-at-value' },
     'document',
-    { name: '-moz-document', type: 'document', prefix: '-moz-' }
+    { name: '-moz-document', type: 'document', prefix: '-moz-' },
+    'page'
   ];
 
   // -- Functions ------------------------------------------------------------
@@ -330,9 +331,14 @@ function lex(css) {
         token.name = buffer.trim();
 
         // XXX: @-rules are starting to get hairy
-        if (token.type === 'font-face' || token.type === 'viewport') {
+        switch (token.type) {
+        case 'font-face':
+        case 'viewport' :
+        case 'page'     :
           pushState('before-name');
-        } else {
+          break;
+
+        default:
           pushState('before-selector');
         }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -126,9 +126,18 @@ function parseAtGroup(token) {
   // temporarily. They will later be used as `tokenize()` overrides.
   var overrides = {};
 
-  if (token.type === 'font-face' || token.type === 'viewport') {
+  switch (token.type) {
+  case 'font-face':
+  case 'viewport' :
     overrides.declarations = parseDeclarations();
-  } else {
+    break;
+
+  case 'page':
+    overrides.prefix = token.prefix;
+    overrides.declarations = parseDeclarations();
+    break;
+
+  default:
     overrides.prefix = token.prefix;
     overrides.rules = parseRules();
   }
@@ -224,7 +233,8 @@ function parseToken(token) {
   case 'font-face':
   case 'supports' :
   case 'viewport' :
-  case 'document' : return parseAtGroup(token);
+  case 'document' :
+  case 'page'     : return parseAtGroup(token);
   }
 
   DEBUG && debug('parseToken: unexpected token:', JSON.stringify(token));

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -95,11 +95,14 @@ function stringifyAtGroup(node) {
   var label = '';
   var prefix = node.prefix || '';
 
-  if (node.rules && node.name) {
+  if (node.name) {
     label = ' ' + node.name;
   }
 
-  return '@' + prefix + node.type + label + _s + stringifyBlock(node, true) + _n;
+  // FIXME: @-rule conditional logic is leaking everywhere.
+  var chomp = node.type !== 'page';
+
+  return '@' + prefix + node.type + label + _s + stringifyBlock(node, chomp) + _n;
 }
 
 /**
@@ -162,6 +165,7 @@ function reduce(items, fn) {
  * @param {Object} node AST node
  * @returns {String}
  */
+// FIXME: chomp should not be a magic boolean parameter
 function stringifyBlock(node, chomp) {
   var children = node.declarations;
   var fn = stringifyDeclaration;
@@ -234,7 +238,8 @@ function stringifyNode(node) {
   case 'font-face':
   case 'supports' :
   case 'viewport' :
-  case 'document' : return stringifyAtGroup(node);
+  case 'document' :
+  case 'page'     : return stringifyAtGroup(node);
   }
 
   DEBUG && debug('stringifyNode: unexpected node: ' + JSON.stringify(node));

--- a/test/fixtures/tests.js
+++ b/test/fixtures/tests.js
@@ -504,6 +504,46 @@ exports['@namespace'] = {
 
 // -- @page --------------------------------------------------------------------
 
+exports['@page'] = {
+  css: '@page :pseudo-class { margin: 2in; }',
+
+  lex: [{
+    type: 'page',
+    start: { line: 1, col: 1 },
+    name: ':pseudo-class',
+    end: { line: 1, col: 17 }
+  }, { type: 'property',
+    start: { line: 1, col: 19 },
+    name: 'margin',
+    value: '2in',
+    end: { line: 1, col: 30 }
+  }, { type: 'end',
+    start: { line: 1, col: 32 },
+    end: { line: 1, col: 32 }
+  }, { type: 'at-group-end',
+    start: { line: 1, col: 32 },
+    end: { line: 1, col: 32 }
+  }],
+
+  parse: [{
+    expect: {
+      type: "stylesheet",
+      stylesheet: {
+        rules: [{
+          type: "page",
+          name: ":pseudo-class",
+          prefix: undefined,
+          declarations: [{
+            type: "property",
+            name: "margin",
+            value: "2in"
+          }]
+        }]
+      }
+    }
+  }]
+};
+
 // -- @supports ----------------------------------------------------------------
 
 exports['@supports'] = {

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -151,15 +151,3 @@ describe('General Syntax', function () {
   });
 
 });
-
-describe('@page', function () {
-  it('should work', function () {
-    var css = [
-      '@page :pseudo-class {',
-        'margin: 2in;',
-      '}'
-    ].join('\n');
-
-    ensure(css);
-  });
-});


### PR DESCRIPTION
Supports prefix-less `@document`, `@namespace` and `@page`, as well as the prefixed `@-moz-document`.
