### PR TITLE
Fixes column/line computation for comments and at-rules, + fix curly braces in strings + fix parsing when property value is missing + keep \n and \t in propery values.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.11"

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -300,10 +300,14 @@ function lex(css) {
     case ';':
       switch (getState()) {
       case 'name':
+      case 'before-value':
       case 'value':
         // Tokenize a declaration
-        token.value = buffer.trim(),
-        addToken();
+        // if value is empty skip the declaration
+        if (buffer.trim().length > 0) {
+          token.value = buffer.trim(),
+          addToken();
+        }
         replaceState('before-name');
         break;
 
@@ -390,6 +394,7 @@ function lex(css) {
       switch (getState()) {
       case 'before-name':
       case 'name':
+      case 'before-value':
       case 'value':
         // If the buffer contains anything, it is a value
         if (buffer) {

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -252,6 +252,9 @@ function lex(css) {
     case '\r':
     case '\f':
       switch (getState()) {
+      case 'value':
+      case 'value-paren':
+      case 'at-group':
       case 'comment':
       case 'single-string':
       case 'double-string':

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -161,7 +161,7 @@ function lex(css) {
   	if ((n || 1) == 1) {
   		if (css[cursor] == '\n') {
   			line++;
-  			column = 0;
+  			column = 1;
   		} else {
   			column++;
   		}
@@ -170,7 +170,7 @@ function lex(css) {
 			var skipStr = css.slice(cursor, cursor + n).split('\n');
 			if (skipStr.length > 1) {
   			line += skipStr.length - 1;
-  			column = 0;
+  			column = 1;
   		}
   		column += skipStr[skipStr.length - 1].length;
     	cursor = cursor + n;

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -346,6 +346,7 @@ function lex(css) {
         token.text = buffer.trim();
         addToken();
         replaceState('before-name');
+        depth = depth + 1;
         break;
 
       case 'at-group':
@@ -365,6 +366,7 @@ function lex(css) {
         }
 
         addToken();
+        depth = depth + 1;
         break;
 
       case 'name':
@@ -373,6 +375,7 @@ function lex(css) {
         token.name = buffer.trim();
         addToken();
         pushState('before-name');
+        depth = depth + 1;
         break;
 
       case 'comment':
@@ -381,11 +384,6 @@ function lex(css) {
         // Ignore braces in comments and strings
         buffer += ch;
         break;
-      }
-
-      // Increment nesting depth if not in a comment
-      if ('comment' !== getState()) {
-        depth = depth + 1;
       }
 
       break;
@@ -418,6 +416,10 @@ function lex(css) {
           addToken();
           popState();
         }
+        
+        if (depth > 0) {
+          depth = depth - 1;
+        }
 
         break;
 
@@ -442,6 +444,9 @@ function lex(css) {
           popState();
         }
 
+        if (depth > 0) {
+          depth = depth - 1;
+        }
         break;
 
       case 'double-string':
@@ -450,10 +455,6 @@ function lex(css) {
         // Ignore braces in comments and strings.
         buffer += ch;
         break;
-      }
-
-      if (depth > 0 && 'comment' !== getState()) {
-        depth = depth - 1;
       }
 
       break;

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -158,23 +158,23 @@ function lex(css) {
    * @param {Number} [n=1] Number of characters to skip.
    */
   function skip(n) {
-  	if ((n || 1) == 1) {
-  		if (css[cursor] == '\n') {
-  			line++;
-  			column = 1;
-  		} else {
-  			column++;
-  		}
-  		cursor++;
-  	} else {
-			var skipStr = css.slice(cursor, cursor + n).split('\n');
-			if (skipStr.length > 1) {
-  			line += skipStr.length - 1;
-  			column = 1;
-  		}
-  		column += skipStr[skipStr.length - 1].length;
-    	cursor = cursor + n;
-		}
+    if ((n || 1) == 1) {
+      if (css[cursor] == '\n') {
+        line++;
+        column = 1;
+      } else {
+        column++;
+      }
+      cursor++;
+    } else {
+      var skipStr = css.slice(cursor, cursor + n).split('\n');
+      if (skipStr.length > 1) {
+        line += skipStr.length - 1;
+        column = 1;
+      }
+      column += skipStr[skipStr.length - 1].length;
+      cursor = cursor + n;
+    }
   }
 
   /**

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -152,13 +152,29 @@ function lex(css) {
   }
 
   /**
-   * Move the character cursor. Positive numbers move the cursor forward,
-   * negative numbers move the cursor backward.
+   * Move the character cursor. Positive numbers move the cursor forward.
+   * Negative numbers are not supported!
    *
    * @param {Number} [n=1] Number of characters to skip.
    */
   function skip(n) {
-    cursor = cursor + (n || 1);
+  	if ((n || 1) == 1) {
+  		if (css[cursor] == '\n') {
+  			line++;
+  			column = 0;
+  		} else {
+  			column++;
+  		}
+  		cursor++;
+  	} else {
+			var skipStr = css.slice(cursor, cursor + n).split('\n');
+			if (skipStr.length > 1) {
+  			line += skipStr.length - 1;
+  			column = 0;
+  		}
+  		column += skipStr[skipStr.length - 1].length;
+    	cursor = cursor + n;
+		}
   }
 
   /**
@@ -211,7 +227,7 @@ function lex(css) {
   while (ch = getCh()) {
     DEBUG && debug(ch, getState());
 
-    column += 1;
+    // column += 1;
 
     switch (ch) {
     // Space
@@ -253,10 +269,10 @@ function lex(css) {
         break;
       }
 
-      if ('\n' === ch) {
-        column = 0;
-        line += 1;
-      }
+      // if ('\n' === ch) {
+      //   column = 0;
+      //   line += 1;
+      // }
       break;
 
     case ':':
@@ -506,9 +522,9 @@ function lex(css) {
       default:
         if (isNextChar('*')) {
           // Create a comment token
-          skip();
           initializeToken('comment');
           pushState('comment');
+          skip();
         }
         else {
           buffer += ch;
@@ -567,9 +583,9 @@ function lex(css) {
 
           tokenized = true;
 
-          skip(name.length);
           initializeToken(name);
           pushState(rule.state || 'at-group');
+          skip(name.length);
 
           if (rule.prefix) {
             token.prefix = rule.prefix;

--- a/test/escapes.js
+++ b/test/escapes.js
@@ -8,10 +8,10 @@ var mensch = require('..');
 describe('CSS Escape Sequences', function () {
   it('should be supported', function () {
     var file = path.join(__dirname, 'fixtures', 'escapes.css');
-    var css = fs.readFileSync(file, 'utf-8');
+    var css = fs.readFileSync(file, 'utf-8').replace(/\r\n/g, '\n');
 
     var ast = mensch.parse(css, {comments: true});
-    var out = mensch.stringify(ast, {comments: true, compress: true});
+    var out = mensch.stringify(ast, {comments: true, compress: true}).replace(/\r\n/g, '\n');
 
     assert.equal(out, css);
   });

--- a/test/fixtures/tests.js
+++ b/test/fixtures/tests.js
@@ -9,7 +9,7 @@ exports.comment = {
     type: 'comment',
     text: ' body { color: black; } ',
     start: { line: 1, col: 1 },
-    end: { line: 1, col: 26 }
+    end: { line: 1, col: 28 }
   }],
 
   parse: [{
@@ -95,7 +95,7 @@ exports['@charset'] = {
     type: 'charset',
     value: '"UTF-8"',
     start: { col: 1, line: 1 },
-    end: { col: 10, line: 1 }
+    end: { col: 17, line: 1 }
   }],
 
   parse: [{
@@ -131,32 +131,32 @@ exports['@document'] = {
                 'domain(mozilla.org),' +
                 'regexp("https:.*")',
         start: { col: 1, line: 1 },
-        end: { col: 103, line: 1 }
+        end: { col: 111, line: 1 }
       }, {
         type: 'selector',
-        start: { line: 1, col: 105 },
+        start: { line: 1, col: 113 },
         text: 'body',
-        end: { line: 1, col: 110 }
+        end: { line: 1, col: 118 }
       }, {
         type: 'property',
-        start: { line: 1, col: 112 },
+        start: { line: 1, col: 120 },
         name: 'color',
         value: 'purple',
-        end: { line: 1, col: 125 }
+        end: { line: 1, col: 133 }
       }, {
         type: 'property',
-        start: { line: 1, col: 127 },
+        start: { line: 1, col: 135 },
         name: 'background',
         value: 'yellow',
-        end: { line: 1, col: 145 }
+        end: { line: 1, col: 153 }
       }, {
         type: 'end',
-        start: { line: 1, col: 147 },
-        end: { line: 1, col: 147 }
+        start: { line: 1, col: 155 },
+        end: { line: 1, col: 155 }
       }, {
         type: 'at-group-end',
-        start: { line: 1, col: 149 },
-        end: { line: 1, col: 149 }
+        start: { line: 1, col: 157 },
+        end: { line: 1, col: 157 }
       }],
 
       parse: [{
@@ -229,7 +229,7 @@ exports['@import'] = {
     type: 'import',
     value: '"foo.css" print',
     start: { col: 1, line: 1 },
-    end: { col: 18, line: 1 }
+    end: { col: 24, line: 1 }
   }],
 
   parse: [{
@@ -254,27 +254,27 @@ exports['@font-face'] = {
     type: 'font-face',
     name: '',
     start: { col: 1, line: 1 },
-    end: { col: 3, line: 1 }
+    end: { col: 12, line: 1 }
   }, {
     type: 'property',
     name: 'font-family',
     value: 'Gentium',
-    start: { col: 5, line: 1 },
-    end: { col: 25, line: 1 }
+    start: { col: 14, line: 1 },
+    end: { col: 34, line: 1 }
   }, {
     type: 'property',
     name: 'src',
     value: 'url(http://example.com/fonts/Gentium.ttf)',
-    start: { col: 27, line: 1 },
-    end: { col: 73, line: 1 }
+    start: { col: 36, line: 1 },
+    end: { col: 82, line: 1 }
   }, {
     type: 'end',
-    start: { col: 74, line: 1 },
-    end: { col: 74, line: 1 }
+    start: { col: 83, line: 1 },
+    end: { col: 83, line: 1 }
   }, {
     type: 'at-group-end',
-    start: { col: 74, line: 1 },
-    end: { col: 74, line: 1 }
+    start: { col: 83, line: 1 },
+    end: { col: 83, line: 1 }
   }],
 
   parse: [{
@@ -307,41 +307,41 @@ exports['@keyframes'] = {
     type: 'keyframes',
     name: 'foo',
     start: { line: 1, col: 1 },
-    end: { line: 1, col: 7 }
+    end: { line: 1, col: 16 }
   }, {
     type: 'selector',
     text: 'from',
-    start: { line: 1, col: 9 },
-    end: { line: 1, col: 14 }
+    start: { line: 1, col: 18 },
+    end: { line: 1, col: 23 }
   }, {
     type: 'property',
     name: 'opacity',
     value: '0',
-    start: { line: 1, col: 16 },
-    end: { line: 1, col: 26 }
+    start: { line: 1, col: 25 },
+    end: { line: 1, col: 35 }
   }, {
     type: 'end',
-    start: { line: 1, col: 28 },
-    end: { line: 1, col: 28 }
+    start: { line: 1, col: 37 },
+    end: { line: 1, col: 37 }
   }, {
     type: 'selector',
     text: 'to',
-    start: { line: 1, col: 30 },
-    end: { line: 1, col: 33 }
+    start: { line: 1, col: 39 },
+    end: { line: 1, col: 42 }
   }, {
     type: 'property',
     name: 'opacity',
     value: '1',
-    start: { line: 1, col: 35 },
-    end: { line: 1, col: 45 }
+    start: { line: 1, col: 44 },
+    end: { line: 1, col: 54 }
   }, {
     type: 'end',
-    start: { line: 1, col: 47 },
-    end: { line: 1, col: 47 }
+    start: { line: 1, col: 56 },
+    end: { line: 1, col: 56 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 49 },
-    end: { line: 1, col: 49 }
+    start: { line: 1, col: 58 },
+    end: { line: 1, col: 58 }
   }],
 
   parse: [{
@@ -453,26 +453,26 @@ exports['@media'] = {
     type: 'media',
     name: 'screen and (min-width: 700px)',
     start: { line: 1, col: 1 },
-    end: { line: 1, col: 33 }
+    end: { line: 1, col: 38 }
   }, {
     type: 'selector',
     text: 'body',
-    start: { line: 1, col: 35 },
-    end: { line: 1, col: 40 }
+    start: { line: 1, col: 40 },
+    end: { line: 1, col: 45 }
   }, {
     type: 'property',
     name: 'color',
     value: 'black',
-    start: { line: 1, col: 42 },
-    end: { line: 1, col: 54 }
+    start: { line: 1, col: 47 },
+    end: { line: 1, col: 59 }
   }, {
     type: 'end',
-    start: { line: 1, col: 56 },
-    end: { line: 1, col: 56 }
+    start: { line: 1, col: 61 },
+    end: { line: 1, col: 61 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 58 },
-    end: { line: 1, col: 58 }
+    start: { line: 1, col: 63 },
+    end: { line: 1, col: 63 }
   }],
 
   parse: [{
@@ -509,17 +509,17 @@ exports['@namespace'] = {
     type: 'namespace',
     start: { line: 1, col: 1 },
     value: 'url(http://www.w3.org/1999/xhtml)',
-    end: { line: 1, col: 36 }
+    end: { line: 1, col: 45 }
   }, {
     type: 'namespace',
-    start: { line: 1, col: 38 },
+    start: { line: 1, col: 47 },
     value: 'svg url(http://www.w3.org/2000/svg)',
-    end: { line: 1, col: 75 }
+    end: { line: 1, col: 93 }
   }, {
     type: 'namespace',
-    start: { line: 1, col: 77 },
+    start: { line: 1, col: 95 },
     value: '"booga"',
-    end: { line: 1, col: 86 }
+    end: { line: 1, col: 113 }
   }],
 
   parse: [{
@@ -550,18 +550,18 @@ exports['@page'] = {
     type: 'page',
     start: { line: 1, col: 1 },
     name: ':pseudo-class',
-    end: { line: 1, col: 17 }
+    end: { line: 1, col: 21 }
   }, { type: 'property',
-    start: { line: 1, col: 19 },
+    start: { line: 1, col: 23 },
     name: 'margin',
     value: '2in',
-    end: { line: 1, col: 30 }
+    end: { line: 1, col: 34 }
   }, { type: 'end',
-    start: { line: 1, col: 32 },
-    end: { line: 1, col: 32 }
+    start: { line: 1, col: 36 },
+    end: { line: 1, col: 36 }
   }, { type: 'at-group-end',
-    start: { line: 1, col: 32 },
-    end: { line: 1, col: 32 }
+    start: { line: 1, col: 36 },
+    end: { line: 1, col: 36 }
   }],
 
   parse: [{
@@ -592,26 +592,26 @@ exports['@supports'] = {
     type: 'supports',
     name: '(display: table-cell)',
     start: { line: 1, col: 1 },
-    end: { line: 1, col: 25 }
+    end: { line: 1, col: 33 }
   }, {
     type: 'selector',
     text: 'body',
-    start: { line: 1, col: 27 },
-    end: { line: 1, col: 32 }
+    start: { line: 1, col: 35 },
+    end: { line: 1, col: 40 }
   }, {
     type: 'property',
     name: 'color',
     value: 'black',
-    start: { line: 1, col: 34 },
-    end: { line: 1, col: 46 }
+    start: { line: 1, col: 42 },
+    end: { line: 1, col: 54 }
   }, {
     type: 'end',
-    start: { line: 1, col: 48 },
-    end: { line: 1, col: 48 }
+    start: { line: 1, col: 56 },
+    end: { line: 1, col: 56 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 50 },
-    end: { line: 1, col: 50 }
+    start: { line: 1, col: 58 },
+    end: { line: 1, col: 58 }
   }],
 
   parse: [{
@@ -646,21 +646,21 @@ exports['@viewport'] = {
     type: 'viewport',
     name: '',
     start: { col: 1, line: 1 },
-    end: { col: 3, line: 1 }
+    end: { col: 11, line: 1 }
   }, {
     type: 'property',
     name: 'width',
     value: '320px auto',
-    start: { col: 5, line: 1 },
-    end: { col: 22, line: 1 }
+    start: { col: 13, line: 1 },
+    end: { col: 30, line: 1 }
   }, {
     type: 'end',
-    start: { col: 23, line: 1 },
-    end: { col: 23, line: 1 }
+    start: { col: 31, line: 1 },
+    end: { col: 31, line: 1 }
   }, {
     type: 'at-group-end',
-    start: { col: 23, line: 1 },
-    end: { col: 23, line: 1 }
+    start: { col: 31, line: 1 },
+    end: { col: 31, line: 1 }
   }],
 
   parse: [{
@@ -700,55 +700,55 @@ exports['nested @-groups'] = {
     type: 'media',
     name: 'print',
     start: { line: 1, col: 1 },
-    end: { line: 1, col: 9 }
+    end: { line: 1, col: 14 }
   }, {
     type: 'font-face',
     name: '',
-    start: { line: 1, col: 11 },
-    end: { line: 1, col: 13 }
+    start: { line: 1, col: 16 },
+    end: { line: 1, col: 27 }
   }, {
     type: 'property',
     name: 'font-family',
     value: 'Gentium',
-    start: { line: 1, col: 15 },
-    end: { line: 1, col: 35 }
+    start: { line: 1, col: 29 },
+    end: { line: 1, col: 49 }
   }, {
     type: 'property',
     name: 'src',
     value: 'url(http://example.com/fonts/Gentium.ttf)',
-    start: { line: 1, col: 37 },
-    end: { line: 1, col: 83 }
+    start: { line: 1, col: 51 },
+    end: { line: 1, col: 97 }
   }, {
     type: 'end',
-    start: { line: 1, col: 85 },
-    end: { line: 1, col: 85 }
+    start: { line: 1, col: 99 },
+    end: { line: 1, col: 99 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 85 },
-    end: { line: 1, col: 85 }
+    start: { line: 1, col: 99 },
+    end: { line: 1, col: 99 }
   }, {
     type: 'viewport',
     name: '',
-    start: { line: 1, col: 87 },
-    end: { line: 1, col: 89 }
+    start: { line: 1, col: 101 },
+    end: { line: 1, col: 111 }
   }, {
     type: 'property',
     name: 'width',
     value: '320px auto',
-    start: { line: 1, col: 91 },
-    end: { line: 1, col: 108 }
+    start: { line: 1, col: 113 },
+    end: { line: 1, col: 130 }
   }, {
     type: 'end',
-    start: { line: 1, col: 110 },
-    end: { line: 1, col: 110 }
+    start: { line: 1, col: 132 },
+    end: { line: 1, col: 132 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 110 },
-    end: { line: 1, col: 110 }
+    start: { line: 1, col: 132 },
+    end: { line: 1, col: 132 }
   }, {
     type: 'at-group-end',
-    start: { line: 1, col: 112 },
-    end: { line: 1, col: 112 }
+    start: { line: 1, col: 134 },
+    end: { line: 1, col: 134 }
   }],
 
   parse: [{

--- a/test/position.js
+++ b/test/position.js
@@ -1,0 +1,29 @@
+var assert = require('assert');
+var mensch = require('..');
+
+describe('Parse with options.position=true', function () {
+  describe('with comments', function () {
+  	it('should count comment length', function() {
+  		var css = 'body p {}';
+  		var ast = mensch.parse(css, { comment: true, position: true });
+  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
+  		assert.equal(ast.stylesheet.rules[0].position.end.col, 8);
+  		var css = 'body /* comment */p {}';
+  		var ast = mensch.parse(css, { comment: true, position: true });
+  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
+  		assert.equal(ast.stylesheet.rules[0].position.end.col, 21);
+  		var css = 'body /* multiline \n comment */p {}';
+  		var ast = mensch.parse(css, { comment: true, position: true });
+  		assert.equal(ast.stylesheet.rules[0].position.end.line, 2);
+  		assert.equal(ast.stylesheet.rules[0].position.end.col, 13);
+  	});
+  });
+  describe('with atrules', function () {
+  	it('should count rule length', function() {
+  		var css = '@media screen {}';
+  		var ast = mensch.parse(css, { comment: true, position: true });
+  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
+  		assert.equal(ast.stylesheet.rules[0].position.end.col, 15);
+  	});
+  });
+});

--- a/test/position.js
+++ b/test/position.js
@@ -6,24 +6,36 @@ describe('Parse with options.position=true', function () {
   	it('should count comment length', function() {
   		var css = 'body p {}';
   		var ast = mensch.parse(css, { comment: true, position: true });
-  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
-  		assert.equal(ast.stylesheet.rules[0].position.end.col, 8);
+  		assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 8 } });
   		var css = 'body /* comment */p {}';
   		var ast = mensch.parse(css, { comment: true, position: true });
-  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
-  		assert.equal(ast.stylesheet.rules[0].position.end.col, 21);
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 21 } });
   		var css = 'body /* multiline \n comment */p {}';
   		var ast = mensch.parse(css, { comment: true, position: true });
-  		assert.equal(ast.stylesheet.rules[0].position.end.line, 2);
-  		assert.equal(ast.stylesheet.rules[0].position.end.col, 13);
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 2, col: 14 } });
   	});
   });
   describe('with atrules', function () {
   	it('should count rule length', function() {
   		var css = '@media screen {}';
   		var ast = mensch.parse(css, { comment: true, position: true });
-  		assert.equal(ast.stylesheet.rules[0].position.end.line, 1);
-  		assert.equal(ast.stylesheet.rules[0].position.end.col, 15);
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 15 } });
   	});
+  });
+  describe('positions should be consistents between lines', function() {
+    it('should have same column numbering in first and second line', function() {
+      var css = 'selector { prop: val }\nselector { prop: val }';
+      var ast = mensch.parse(css, { comment: true, position: true });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 2, col: 1 }, end: { line: 2, col: 10 } });
+    })
+    it('should have same column numbering in first and second line and for selector/properties', function() {
+      var css = 'selector {\nprop: val;\n}\nselector {\nprop: val;\n}';
+      var ast = mensch.parse(css, { comment: true, position: true });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[0].declarations[0].position, { start: { line: 2, col: 1 }, end: { line: 2, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 4, col: 1 }, end: { line: 4, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[1].declarations[0].position, { start: { line: 5, col: 1 }, end: { line: 5, col: 10 } });
+    })
   });
 });

--- a/test/position.js
+++ b/test/position.js
@@ -3,24 +3,24 @@ var mensch = require('..');
 
 describe('Parse with options.position=true', function () {
   describe('with comments', function () {
-  	it('should count comment length', function() {
-  		var css = 'body p {}';
-  		var ast = mensch.parse(css, { comment: true, position: true });
-  		assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 8 } });
-  		var css = 'body /* comment */p {}';
-  		var ast = mensch.parse(css, { comment: true, position: true });
+    it('should count comment length', function() {
+      var css = 'body p {}';
+      var ast = mensch.parse(css, { comment: true, position: true });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 8 } });
+      var css = 'body /* comment */p {}';
+      var ast = mensch.parse(css, { comment: true, position: true });
       assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 21 } });
-  		var css = 'body /* multiline \n comment */p {}';
-  		var ast = mensch.parse(css, { comment: true, position: true });
+      var css = 'body /* multiline \n comment */p {}';
+      var ast = mensch.parse(css, { comment: true, position: true });
       assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 2, col: 14 } });
-  	});
+    });
   });
   describe('with atrules', function () {
-  	it('should count rule length', function() {
-  		var css = '@media screen {}';
-  		var ast = mensch.parse(css, { comment: true, position: true });
+    it('should count rule length', function() {
+      var css = '@media screen {}';
+      var ast = mensch.parse(css, { comment: true, position: true });
       assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 15 } });
-  	});
+    });
   });
   describe('positions should be consistents between lines', function() {
     it('should have same column numbering in first and second line', function() {

--- a/test/real-world.js
+++ b/test/real-world.js
@@ -9,12 +9,12 @@ describe('Real world CSS', function () {
 
   ['cnn', 'espn', 'plus.google', 'twitter', 'yahoo'].forEach(function (name) {
     var file = path.join(__dirname, 'fixtures', name + '.com.css');
-    var css = fs.readFileSync(file, 'utf-8').trim();
+    var css = fs.readFileSync(file, 'utf-8').trim().replace(/\r\n/g, '\n');
     var size = (css.length / 1024).toFixed();
 
     it(name + '.com [' + size + ' kb]', function () {
       var ast = mensch.parse(css, {comments: true});
-      var out = mensch.stringify(ast, {comments: true});
+      var out = mensch.stringify(ast, {comments: true}).replace(/\r\n/g, '\n');
 
       DEBUG && debug(css, out);
 

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -310,5 +310,26 @@ describe('General Syntax', function () {
   	  ensure(css);
   	});
   });
+  
+  describe('lexer whitespace handing', function() {
+  	it('should keep tabs in values', function() {
+  		var css = [
+  		  'a {',
+  		  'border-width: 2px 3px\t4px 5px;',
+  		  '}'
+  	  ].join('\n');
+  	  
+  	  ensure(css);
+  	});
+  	it('should keep newlines in values', function() {
+  		var css = [
+  		  'a {',
+  		  'border-width: 2px 3px\n4px 5px;',
+  		  '}'
+  	  ].join('\n');
+  	  
+  	  ensure(css);
+  	});
+  });
 
 });

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -220,5 +220,59 @@ describe('General Syntax', function () {
       ensure(css);
     });
   });
+  
+  describe('closing brackets in a declaration', function() {
+  	it('should take precedence over value parsing', function() {
+  		var css = [
+  		  'body {background: ;}',
+        '#yo {display: block;}'
+  	  ].join('\n');
+
+      var expect = [
+        'body {}',
+        '',
+        '#yo {',
+        'display: block;',
+        '}'
+      ].join('\n');
+  	  
+  	  ensure(css, expect);
+  	});
+
+  	it('should take precedence over declaration parsing', function() {
+  		var css = [
+  		  'body {background:}',
+        '#yo {display: block;}'
+  	  ].join('\n');
+
+      var expect = [
+        'body {}',
+        '',
+        '#yo {',
+        'display: block;',
+        '}'
+      ].join('\n');
+  	  
+  	  ensure(css, expect);
+  	});
+  });
+  
+  describe('semicolon in a declaration', function() {
+  	it('should take precedence over value expectation', function() {
+  		var css = [
+  		  'body {background:;line-height:10px;}'
+  	  ].join('\n');
+
+      var expect = [
+        'body {',
+        'line-height: 10px;',
+        '}'
+      ].join('\n');
+  	  
+  	  ensure(css, expect);
+  	});
+  });
+  
+  
 
 });

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -222,11 +222,11 @@ describe('General Syntax', function () {
   });
   
   describe('closing brackets in a declaration', function() {
-  	it('should take precedence over value parsing', function() {
-  		var css = [
-  		  'body {background: ;}',
+    it('should take precedence over value parsing', function() {
+      var css = [
+        'body {background: ;}',
         '#yo {display: block;}'
-  	  ].join('\n');
+      ].join('\n');
 
       var expect = [
         'body {}',
@@ -235,15 +235,15 @@ describe('General Syntax', function () {
         'display: block;',
         '}'
       ].join('\n');
-  	  
-  	  ensure(css, expect);
-  	});
+      
+      ensure(css, expect);
+    });
 
-  	it('should take precedence over declaration parsing', function() {
-  		var css = [
-  		  'body {background:}',
+    it('should take precedence over declaration parsing', function() {
+      var css = [
+        'body {background:}',
         '#yo {display: block;}'
-  	  ].join('\n');
+      ].join('\n');
 
       var expect = [
         'body {}',
@@ -252,84 +252,84 @@ describe('General Syntax', function () {
         'display: block;',
         '}'
       ].join('\n');
-  	  
-  	  ensure(css, expect);
-  	});
+      
+      ensure(css, expect);
+    });
   });
   
   describe('semicolon in a declaration', function() {
-  	it('should take precedence over value expectation', function() {
-  		var css = [
-  		  'body {background:;line-height:10px;}'
-  	  ].join('\n');
+    it('should take precedence over value expectation', function() {
+      var css = [
+        'body {background:;line-height:10px;}'
+      ].join('\n');
 
       var expect = [
         'body {',
         'line-height: 10px;',
         '}'
       ].join('\n');
-  	  
-  	  ensure(css, expect);
-  	});
+      
+      ensure(css, expect);
+    });
   });
   
   describe('opening and closing brackets in comments', function() {
-  	it('should be ignored', function() {
-  		var css = [
-  		  '@media tty {',
-  		  'i {',
-  		  'color: /* } */ black;',
-  		  '}',
-  		  '}',
-  		  '',
-  		  'a {',
-  		  'color: white;',
-  		  '}'
-  	  ].join('\n');
+    it('should be ignored', function() {
+      var css = [
+        '@media tty {',
+        'i {',
+        'color: /* } */ black;',
+        '}',
+        '}',
+        '',
+        'a {',
+        'color: white;',
+        '}'
+      ].join('\n');
 
-  	  var expect = css.replace('/* } */ ', '');
-  	  
-  	  ensure(css, expect);
-  	});
+      var expect = css.replace('/* } */ ', '');
+      
+      ensure(css, expect);
+    });
   });
   
   describe('opening and closing brackets in strings', function() {
-  	it('should be ignored', function() {
-  		var css = [
-  		  '@media tty {',
-  		  'i {',
-  		  'content: "\\";/*" "*/}} a { color: black; } /*";',
-  		  '}',
-  		  '}',
-  		  '',
-  		  'a {',
-  		  'color: white;',
-  		  '}'
-  	  ].join('\n');
-  	  
-  	  ensure(css);
-  	});
+    it('should be ignored', function() {
+      var css = [
+        '@media tty {',
+        'i {',
+        'content: "\\";/*" "*/}} a { color: black; } /*";',
+        '}',
+        '}',
+        '',
+        'a {',
+        'color: white;',
+        '}'
+      ].join('\n');
+      
+      ensure(css);
+    });
   });
   
   describe('lexer whitespace handing', function() {
-  	it('should keep tabs in values', function() {
-  		var css = [
-  		  'a {',
-  		  'border-width: 2px 3px\t4px 5px;',
-  		  '}'
-  	  ].join('\n');
-  	  
-  	  ensure(css);
-  	});
-  	it('should keep newlines in values', function() {
-  		var css = [
-  		  'a {',
-  		  'border-width: 2px 3px\n4px 5px;',
-  		  '}'
-  	  ].join('\n');
-  	  
-  	  ensure(css);
-  	});
+    it('should keep tabs in values', function() {
+      var css = [
+        'a {',
+        'border-width: 2px 3px\t4px 5px;',
+        '}'
+      ].join('\n');
+      
+      ensure(css);
+    });
+    it('should keep newlines in values', function() {
+      var css = [
+        'a {',
+        'border-width: 2px 3px\n4px 5px;',
+        '}'
+      ].join('\n');
+      
+      ensure(css);
+    });
   });
 
 });

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -273,6 +273,42 @@ describe('General Syntax', function () {
   	});
   });
   
+  describe('opening and closing brackets in comments', function() {
+  	it('should be ignored', function() {
+  		var css = [
+  		  '@media tty {',
+  		  'i {',
+  		  'color: /* } */ black;',
+  		  '}',
+  		  '}',
+  		  '',
+  		  'a {',
+  		  'color: white;',
+  		  '}'
+  	  ].join('\n');
+
+  	  var expect = css.replace('/* } */ ', '');
+  	  
+  	  ensure(css, expect);
+  	});
+  });
   
+  describe('opening and closing brackets in strings', function() {
+  	it('should be ignored', function() {
+  		var css = [
+  		  '@media tty {',
+  		  'i {',
+  		  'content: "\\";/*" "*/}} a { color: black; } /*";',
+  		  '}',
+  		  '}',
+  		  '',
+  		  'a {',
+  		  'color: white;',
+  		  '}'
+  	  ].join('\n');
+  	  
+  	  ensure(css);
+  	});
+  });
 
 });


### PR DESCRIPTION
My attempt at fixing https://github.com/brettstimmerman/mensch/issues/15 and more.
See new test position.js for fixed expectations.

Moved the col/line computation inside the "skip" method, so to make sure it is always invoked when moving the cursor. NOTE: The method could be optimized and does not support negative movements.