### PR TITLE
Rules parsed with position=true should have the end curly brace be th…

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -140,7 +140,7 @@ function parseAtGroup(token) {
 
   default:
     overrides.prefix = token.prefix;
-    overrides.rules = parseRules();
+    overrides.rules = parseRules(_depth);
   }
 
   var node = astNode(token, overrides);
@@ -302,6 +302,6 @@ function parseDeclarations() {
  *
  * @returns {Array} rule nodes
  */
-function parseRules() {
-  return parseTokensWhile(function () { return _depth; });
+function parseRules(depth) {
+  return parseTokensWhile(function () { return _depth === depth; });
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -10,6 +10,7 @@ var _comments;   // Whether comments are allowed.
 var _depth;      // Current block nesting depth.
 var _position;   // Whether to include line/column position.
 var _tokens;     // Array of lexical tokens.
+var _endToken; // The last end or at-group-end lexical token.
 
 /**
  * Convert a CSS string or array of lexical tokens into a `stringify`-able AST.
@@ -142,7 +143,12 @@ function parseAtGroup(token) {
     overrides.rules = parseRules();
   }
 
-  return astNode(token, overrides);
+  var node = astNode(token, overrides);
+  if (_position) {
+    node.position.end = _endToken.end;
+  }
+
+  return node;
 }
 
 /**
@@ -199,11 +205,17 @@ function parseSelector(token) {
     return str.trim();
   }
 
-  return astNode(token, {
+  var node = astNode(token, {
     type: 'rule',
     selectors: token.text.split(',').map(trim),
     declarations: parseDeclarations(token)
   });
+
+  if (_position) {
+    node.position.end = _endToken.end;
+  }
+
+  return node;
 }
 
 /**
@@ -218,7 +230,7 @@ function parseToken(token) {
 
   case 'selector': return parseSelector(token);
 
-  case 'at-group-end': _depth = _depth - 1; return;
+  case 'at-group-end': _depth = _depth - 1; _endToken = token; return;
 
   case 'media'     :
   case 'keyframes' :return parseAtGroup(token);
@@ -262,9 +274,13 @@ function parseTokensWhile(conditionFn) {
     node && nodes.push(node);
   }
 
-  // Place an unused non-`end` lexical token back onto the stack.
-  if (token && token.type !== 'end') {
-    _tokens.unshift(token);
+  // Place a lexical token back onto the stack.
+  if (token) {
+    if (token.type !== 'end') {
+      _tokens.unshift(token);
+    } else {
+      _endToken = token;
+    }
   }
 
   return nodes;

--- a/test/fixtures/tests.js
+++ b/test/fixtures/tests.js
@@ -828,7 +828,7 @@ exports.position = {
           }],
           position: {
             start: { line: 1, col: 1 },
-            end: { line: 1, col: 6 }
+            end: { line: 1, col: 22 }
           }
         }]
       }

--- a/test/position.js
+++ b/test/position.js
@@ -6,35 +6,35 @@ describe('Parse with options.position=true', function () {
     it('should count comment length', function() {
       var css = 'body p {}';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 8 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 9 } });
       var css = 'body /* comment */p {}';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 21 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 22 } });
       var css = 'body /* multiline \n comment */p {}';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 2, col: 14 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 2, col: 15 } });
     });
   });
   describe('with atrules', function () {
     it('should count rule length', function() {
       var css = '@media screen {}';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 15 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 16 } });
     });
   });
-  describe('positions should be consistents between lines', function() {
+  describe('positions should be consistent between lines', function() {
     it('should have same column numbering in first and second line', function() {
       var css = 'selector { prop: val }\nselector { prop: val }';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 10 } });
-      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 2, col: 1 }, end: { line: 2, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 22 } });
+      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 2, col: 1 }, end: { line: 2, col: 22 } });
     })
     it('should have same column numbering in first and second line and for selector/properties', function() {
       var css = 'selector {\nprop: val;\n}\nselector {\nprop: val;\n}';
       var ast = mensch.parse(css, { comment: true, position: true });
-      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 1, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[0].position, { start: { line: 1, col: 1 }, end: { line: 3, col: 1 } });
       assert.deepEqual(ast.stylesheet.rules[0].declarations[0].position, { start: { line: 2, col: 1 }, end: { line: 2, col: 10 } });
-      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 4, col: 1 }, end: { line: 4, col: 10 } });
+      assert.deepEqual(ast.stylesheet.rules[1].position, { start: { line: 4, col: 1 }, end: { line: 6, col: 1 } });
       assert.deepEqual(ast.stylesheet.rules[1].declarations[0].position, { start: { line: 5, col: 1 }, end: { line: 5, col: 10 } });
     })
   });


### PR DESCRIPTION
Rules parsed with position=true should have the end curly brace be the end position, not the end of the selector/at-rule.

Signed-off-by: Jonathan Horowitz <jhorowitz@firedrum.com>