### PR TITLE
Fix global leak and stringify indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -6,6 +6,7 @@ var debug = require('./debug')('stringify');
 var _comments;      // Whether comments are allowed in the stringified CSS.
 var _compress;      // Whether the stringified CSS should be compressed.
 var _indentation;   // Indentation option value.
+var _level;         // Current indentation level.
 var _n;             // Compression-aware newline character.
 var _s;             // Compression-aware space character.
 
@@ -28,6 +29,7 @@ function stringify(ast, options) {
   _indentation = options.indentation || '';
   _compress = !!options.compress;
   _comments = !!options.comments;
+  _level = 1;
 
   if (_compress) {
     _n = _s = '';
@@ -55,16 +57,14 @@ function stringify(ast, options) {
  * @returns {String} sequence of spaces
  */
 function indent(level) {
-  this.level || (this.level = 1);
-
   if (level) {
-    this.level += level;
+    _level += level;
     return;
   }
 
   if (_compress) { return ''; }
 
-  return Array(this.level).join(_indentation || '');
+  return Array(_level).join(_indentation || '');
 }
 
 // -- Stringify Functions ------------------------------------------------------


### PR DESCRIPTION
The indent method was leaking into the global scope, so this PR cleans that up by adding a file-scoped `_level` variable.  This variable is also initialized inside the `stringify` function rather than in the level function so that if `stringify` were to ever throw an exception, subsequent calls would not use the wrong indentation level.

Please let me know if you need any information or need me to do anything to help get this merged in!